### PR TITLE
 multi-node DDP helpers and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# GPU Programming Experiments
+
+## Multi-node over two laptops
+
+1. **Find your LAN IP**
+   - Linux: `ip addr`
+   - Windows: `ipconfig`
+   - WSL2: run `ip addr` inside the WSL terminal
+2. **Open the firewall for port 29500**
+   - Linux with UFW: `sudo ufw allow 29500`
+   - Windows: allow inbound TCP for 29500 in Windows Defender Firewall
+3. **Use identical code and Python environment on both machines**
+
+### Environment check
+Run on each laptop:
+
+```bash
+python scripts/env_check.py
+```
+
+### Training launcher examples
+Master (Laptop A):
+
+```bash
+MASTER_ADDR=192.168.1.50 MASTER_PORT=29500 WORLD_SIZE=2 \
+NODE_RANK=0 ./scripts/launch_master.sh --cmd "python train.py --mode ddp --devices 1 --config configs/tiny.yaml --mixed_precision fp16 --gradient_checkpointing --max_steps 200"
+```
+
+Worker (Laptop B):
+
+```bash
+MASTER_ADDR=192.168.1.50 MASTER_PORT=29500 WORLD_SIZE=2 \
+NODE_RANK=1 ./scripts/launch_worker.sh --cmd "python train.py --mode ddp --devices 1 --config configs/tiny.yaml --mixed_precision fp16 --gradient_checkpointing --max_steps 200"
+```
+
+### DDP sanity test examples
+Master:
+
+```bash
+MASTER_ADDR=192.168.1.50 MASTER_PORT=29500 WORLD_SIZE=2 NODE_RANK=0 \
+torchrun --nnodes=2 --nproc_per_node=1 --node_rank=0 --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT \
+  scripts/ddp_test_allreduce.py --backend nccl
+```
+
+Worker:
+
+```bash
+MASTER_ADDR=192.168.1.50 MASTER_PORT=29500 WORLD_SIZE=2 NODE_RANK=1 \
+torchrun --nnodes=2 --nproc_per_node=1 --node_rank=1 --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT \
+  scripts/ddp_test_allreduce.py --backend nccl
+```
+
+### Troubleshooting
+- NCCL timeouts? try wired Ethernet, ensure both nodes can ping each other, open firewall for 29500, set `NCCL_DEBUG=INFO`.
+- If still flaky on Wi-Fi/WSL2, allow fallback envs:
+  ```bash
+  export NCCL_IB_DISABLE=1
+  export NCCL_P2P_DISABLE=1
+  export GLOO_SOCKET_IFNAME=Ethernet
+  export NCCL_SOCKET_IFNAME=Ethernet
+  ```
+- WSL2 users: enable NVIDIA CUDA on WSL and match PyTorch CUDA wheels on both nodes.
+

--- a/configs/tiny.yaml
+++ b/configs/tiny.yaml
@@ -1,0 +1,6 @@
+model_name: distilbert-base-uncased
+seq_len: 128
+per_device_batch_size: 8
+grad_accum_steps: 4
+max_steps: 200
+eval_interval: 50

--- a/scripts/ddp_test_allreduce.py
+++ b/scripts/ddp_test_allreduce.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Minimal DDP all_reduce test."""
+import argparse
+import os
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="DDP all_reduce sanity test")
+    parser.add_argument("--backend", default="nccl", help="distributed backend")
+    parser.add_argument("--timeout", type=int, default=180, help="init timeout in seconds")
+    args = parser.parse_args()
+
+    dist.init_process_group(
+        backend=args.backend, timeout=timedelta(seconds=args.timeout)
+    )
+    rank = dist.get_rank()
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    tensor = torch.ones(1, device="cuda")
+    dist.all_reduce(tensor)
+    print(f"Rank {rank} summed value: {tensor.item()}")
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/env_check.py
+++ b/scripts/env_check.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Print CUDA/NCCL environment information."""
+import os
+import sys
+
+try:
+    import torch
+except Exception as exc:  # pragma: no cover - best effort for missing torch
+    print(f"Failed to import torch: {exc}")
+    sys.exit(1)
+
+CHECK = "\u2705"  # check mark
+
+print(f"{CHECK} torch: {torch.__version__}")
+print(f"{CHECK} torch.cuda.is_available(): {torch.cuda.is_available()}")
+
+if not torch.cuda.is_available():
+    print("CUDA not available. Please verify drivers and GPU access.")
+    sys.exit(1)
+
+print(f"{CHECK} CUDA version: {torch.version.cuda}")
+print(f"{CHECK} NCCL version: {torch.cuda.nccl.version()}")
+print(f"{CHECK} GPU: {torch.cuda.get_device_name(0)}")
+print(f"{CHECK} Device count: {torch.cuda.device_count()}")
+
+for var in ["NCCL_P2P_DISABLE", "NCCL_DEBUG", "CUDA_VISIBLE_DEVICES"]:
+    print(f"{var}={os.environ.get(var)}")

--- a/scripts/launch_master.sh
+++ b/scripts/launch_master.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Master launch script for multi-node training.
+# Example:
+# MASTER_ADDR=192.168.1.50 MASTER_PORT=29500 WORLD_SIZE=2 NODE_RANK=0 \
+#   ./scripts/launch_master.sh --cmd "python train.py ..."
+
+set -e
+
+MASTER_ADDR=${MASTER_ADDR:?MASTER_ADDR not set}
+MASTER_PORT=${MASTER_PORT:-29500}
+WORLD_SIZE=${WORLD_SIZE:-2}
+NNODES=${NNODES:-2}
+NODE_RANK=${NODE_RANK:-0}
+
+CMD=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cmd)
+      shift
+      CMD="$1"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$CMD" ]]; then
+  echo "--cmd argument required"
+  exit 1
+fi
+
+torchrun --nnodes="$NNODES" --nproc_per_node=1 --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" --master_port="$MASTER_PORT" $CMD

--- a/scripts/launch_worker.sh
+++ b/scripts/launch_worker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Worker launch script for multi-node training.
+# Example:
+# MASTER_ADDR=192.168.1.50 MASTER_PORT=29500 WORLD_SIZE=2 NODE_RANK=1 \
+#   ./scripts/launch_worker.sh --cmd "python train.py ..."
+
+set -e
+
+MASTER_ADDR=${MASTER_ADDR:?MASTER_ADDR not set}
+MASTER_PORT=${MASTER_PORT:-29500}
+WORLD_SIZE=${WORLD_SIZE:-2}
+NNODES=${NNODES:-2}
+NODE_RANK=${NODE_RANK:-1}
+
+CMD=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cmd)
+      shift
+      CMD="$1"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$CMD" ]]; then
+  echo "--cmd argument required"
+  exit 1
+fi
+
+torchrun --nnodes="$NNODES" --nproc_per_node=1 --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" --master_port="$MASTER_PORT" $CMD


### PR DESCRIPTION
## Summary
- add `ddp_test_allreduce.py` for a minimal NCCL all-reduce sanity test
- add `launch_master.sh` and `launch_worker.sh` wrappers around `torchrun`
- add `env_check.py` and `configs/tiny.yaml` for quick single-GPU runs
- document two-laptop multi-node setup and troubleshooting

## Testing
- `python -m py_compile scripts/ddp_test_allreduce.py scripts/env_check.py`
- `bash -n scripts/launch_master.sh scripts/launch_worker.sh`
- `python scripts/env_check.py` *(fails: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c614d608fc8329a44c2017d8529f06